### PR TITLE
[bug] 예문의 후리가나와 실제 음성 읽기가 불일치하는 문제 #8

### DIFF
--- a/apps/japanese/src/components/Sentences.tsx
+++ b/apps/japanese/src/components/Sentences.tsx
@@ -31,8 +31,12 @@ const Sentences = ({ sentences }: SentencesProps) => {
       });
   };
 
-  const removeHurigana = (text: string) => {
-    return text.replace(/<rt>(.*?)<\/rt>/g, "").replace(/<[^>]+>/g, "");
+  const removeHurigana = (japaneseText: string) => {
+    return japaneseText.replace(/<rt>(.*?)<\/rt>/g, "").replace(/<[^>]+>/g, "");
+  };
+
+  const extractPronunciation = (japaneseText: string) => {
+    return japaneseText.replace(/<rb>(.*?)<\/rb>/g, "").replace(/<[^>]+>/g, "");
   };
 
   return (
@@ -52,7 +56,7 @@ const Sentences = ({ sentences }: SentencesProps) => {
               disabled={isReadingSentence}
               className="disabled:cursor-not-allowed"
               onClick={() =>
-                handleReadSentence(removeHurigana(item.original), index)
+                handleReadSentence(extractPronunciation(item.original), index)
               }
             >
               <Volume2


### PR DESCRIPTION
## AS-IS

- 일본어 예문을 읽을 때 한자를 기준으로 읽도록 하였음

## TO-BE

- 한자가 아닌 후리가나를 기준으로 예문을 읽어 부정확하게 예문을 읽는 버그를 해결하였음 
