### PR TITLE
[feat] 단어 페이지 로딩 시 문장 없이 아이콘만 보임 #5

### DIFF
--- a/apps/japanese/src/components/Sentences.tsx
+++ b/apps/japanese/src/components/Sentences.tsx
@@ -43,9 +43,8 @@ const Sentences = ({ sentences }: SentencesProps) => {
     <div className="h-64 overflow-auto w-full text-xl rounded-md border p-x-4 space-y-4">
       {sentences.map((item, index) => (
         <div key={index}>
-          <div className="flex items-center space-x-2  ">
+          <div className="flex items-center space-x-2">
             <div
-              className="font-japanese"
               dangerouslySetInnerHTML={{
                 __html: isSentenceMeaningVisible
                   ? item.original

--- a/apps/japanese/src/components/Word.tsx
+++ b/apps/japanese/src/components/Word.tsx
@@ -13,7 +13,7 @@ const Word = ({ original, pronunciation, koreans }: WordProps) => {
 
   return (
     <div className="text-center h-32">
-      <div className="text-4xl font-japanese mb-2">
+      <div className="text-4xl mb-2">
         {original?.split("·").join(", ") || pronunciation}
       </div>
       {isWordMeaningVisible && (

--- a/apps/japanese/src/pages/WordsPage.tsx
+++ b/apps/japanese/src/pages/WordsPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams, Navigate } from "react-router-dom";
+import { useParams, Navigate } from "react-router-dom";
 import { setLocalStorage, useGetMemoryList } from "shared/hooks";
 import { Sentences, Word } from "@/components";
 import { StudyProgress } from "shared/components";
@@ -11,7 +11,6 @@ import {
 
 const WordsPage = () => {
   const { level = "" } = useParams();
-  const navigate = useNavigate();
   const { memoryList, curIndex } = useGetMemoryList(level);
   const words = getWords(level, "japanese");
   const totalLength = words.length;
@@ -22,13 +21,11 @@ const WordsPage = () => {
   const handleGoPrevWord = () => {
     const prevIndex = getPrevIndex(curIndex, totalLength);
     setLocalStorage(level, { memoryList, curIndex: prevIndex });
-    navigate(`/words/${level}/${prevIndex}`);
   };
 
   const handleGoNextWord = () => {
     const nextIndex = getNextIndex(curIndex, totalLength);
     setLocalStorage(level, { memoryList, curIndex: nextIndex });
-    navigate(`/words/${level}/${nextIndex}`);
   };
 
   if (!isValidLevel(level, "japanese")) {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "scripts": {
     "build": "turbo build",
+    "build:chinese": "turbo build --filter=chinese",
+    "build:english": "turbo build --filter=english",
+    "build:french": "turbo build --filter=french",
+    "build:japanese": "turbo build --filter=japanese",
     "dev": "turbo dev",
     "dev:japanese": "turbo dev --filter=japanese",
     "dev:chinese": "turbo dev --filter=chinese",


### PR DESCRIPTION
## AS-IS
- 첫 로딩시에 예문보다 아이콘이 먼저 보임 
- 아이콘이 보이고 약간의 딜레이 후 일본어 예문이 로딩 됨


## TO-BE
- 예문과 아이콘이 동시에 로딩되도록 변경 

## What I did
- 일본어가 들어가는 컴포넌트에 font-japanese tailwind 속성을 제거 

